### PR TITLE
Add Suggests:testthat in the DESCRIPTION file

### DIFF
--- a/simBM/DESCRIPTION
+++ b/simBM/DESCRIPTION
@@ -5,3 +5,4 @@ Maintainer: Yuan Li <li438@wisc.edu>
 License: GPL-2
 Title: Simulate BM data
 Description: Simulate BM data
+Suggests: testthat


### PR DESCRIPTION
If you use the testthat package for your tests, you need to include `Suggests: testthat` in your `DESCRIPTION` file. 

This will prevent the warning message in `R CMD check`:

```
* checking for unstated dependencies in tests ... WARNING
'library' or 'require' call not declared from: 'testthat'
```
